### PR TITLE
Swift 2 support

### DIFF
--- a/EasyAnimation/RBBSpringAnimation/RBBLinearInterpolation.swift
+++ b/EasyAnimation/RBBSpringAnimation/RBBLinearInterpolation.swift
@@ -68,7 +68,7 @@ class RBBInterpolator
         
         //other type?
         if let from: AnyObject = from as? AnyObject, let to: AnyObject = to as? AnyObject {
-            let result: RBBLinearInterpolation = {fraction in
+            let _: RBBLinearInterpolation = {fraction in
                 return (fraction < 0.5) ? from : to
             }
         }
@@ -82,7 +82,7 @@ class RBBInterpolator
             let fromCGColor = from as! CGColorRef
             let toCGColor = to as! CGColorRef
             
-            return self.RBBInterpolateUIColor(UIColor(CGColor: fromCGColor)!, to: UIColor(CGColor: toCGColor)!)
+            return self.RBBInterpolateUIColor(UIColor(CGColor: fromCGColor), to: UIColor(CGColor: toCGColor))
         }
         
         fatalError("Unknown type of animated property")

--- a/EasyAnimation/RBBSpringAnimation/RBBSpringAnimation.swift
+++ b/EasyAnimation/RBBSpringAnimation/RBBSpringAnimation.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-class RBBSpringAnimation: CAKeyframeAnimation, NSCopying {
+class RBBSpringAnimation: CAKeyframeAnimation {
     
     var damping: Double = 0.01
     var velocity: Double = 0.0

--- a/PowerUpYourAnimations.xcodeproj/project.pbxproj
+++ b/PowerUpYourAnimations.xcodeproj/project.pbxproj
@@ -276,7 +276,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Underplot ltd.";
 				TargetAttributes = {
 					9C0471E81B2A38BA00A43D3C = {
@@ -417,6 +417,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -484,6 +485,7 @@
 				INFOPLIST_FILE = PowerUpYourAnimations/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.underplot.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -495,6 +497,7 @@
 				INFOPLIST_FILE = PowerUpYourAnimations/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.underplot.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -513,6 +516,7 @@
 				);
 				INFOPLIST_FILE = PowerUpYourAnimationsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.underplot.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PowerUpYourAnimations.app/PowerUpYourAnimations";
 			};
@@ -528,6 +532,7 @@
 				);
 				INFOPLIST_FILE = PowerUpYourAnimationsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.underplot.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PowerUpYourAnimations.app/PowerUpYourAnimations";
 			};

--- a/PowerUpYourAnimations/AudioViewController.swift
+++ b/PowerUpYourAnimations/AudioViewController.swift
@@ -29,7 +29,7 @@ class AudioViewController: UIViewController {
         
         r.addSublayer(dot)
 
-        UIView.animateWithDuration(0.5, delay: 0.0, options: .CurveEaseOut | .Repeat | .Autoreverse, animations: {
+        UIView.animateWithDuration(0.5, delay: 0.0, options: [.CurveEaseOut, .Repeat, .Autoreverse], animations: {
             dot.transform = CATransform3DMakeScale(1.4, 10, 1.0)
             }, completion: nil)
 
@@ -37,7 +37,7 @@ class AudioViewController: UIViewController {
         r.instanceDelay = 0.1
         r.instanceTransform = CATransform3DMakeTranslation(20.0, 0.0, 0.0)
         
-        UIView.animateWithDuration(1.25, delay: 0.0, options: .Repeat | .Autoreverse, animations: {
+        UIView.animateWithDuration(1.25, delay: 0.0, options: [.Repeat, .Autoreverse], animations: {
             r.instanceTransform = CATransform3DMakeTranslation(10.0, 0.0, 0.0)
         }, completion: nil)
 

--- a/PowerUpYourAnimations/BlueSquareViewController.swift
+++ b/PowerUpYourAnimations/BlueSquareViewController.swift
@@ -25,7 +25,7 @@ class BlueSquareViewController: UIViewController {
             self.blueSquare.layer.cornerRadius = 0.0
             self.blueSquare.layer.borderWidth = 5.0
             
-        }, completion: nil).animateWithDuration(1.0, delay: 0.0, usingSpringWithDamping: 0.33, initialSpringVelocity: 0.0, options: nil, animations: {
+        }, completion: nil).animateWithDuration(1.0, delay: 0.0, usingSpringWithDamping: 0.33, initialSpringVelocity: 0.0, options: [], animations: {
             
             self.blueSquare.transform = CGAffineTransformConcat(
                 CGAffineTransformMakeScale(1.33, 1.33),

--- a/PowerUpYourAnimations/BlueSquareViewController.swift
+++ b/PowerUpYourAnimations/BlueSquareViewController.swift
@@ -18,7 +18,7 @@ class BlueSquareViewController: UIViewController {
         //view.transform = CGAffineTransformMakeScale(2.5, 2.5)
     }
     
-    override func touchesEnded(touches: Set<NSObject>, withEvent event: UIEvent) {
+    override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         
         UIView.animateAndChainWithDuration(0.25, delay: 0.0, options: .CurveEaseOut, animations: {
             self.blueSquare.transform = CGAffineTransformMakeScale(0.8, 0.8)

--- a/PowerUpYourAnimations/CoreImageAnimator.swift
+++ b/PowerUpYourAnimations/CoreImageAnimator.swift
@@ -19,7 +19,7 @@ class CoreImageAnimator: UIPercentDrivenInteractiveTransition, UIViewControllerA
     var presenting = true
     var interactive = false
     
-    func transitionDuration(transitionContext: UIViewControllerContextTransitioning) -> NSTimeInterval {
+    func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
         return animationDuration
     }
     

--- a/PowerUpYourAnimations/CoreImageAnimator.swift
+++ b/PowerUpYourAnimations/CoreImageAnimator.swift
@@ -33,7 +33,7 @@ class CoreImageAnimator: UIPercentDrivenInteractiveTransition, UIViewControllerA
             let fromVC = nav.topViewController as! TimelineViewController
             let toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as! PhotoDetailViewController
             
-            transitionContext.containerView().addSubview(toVC.view)
+            transitionContext.containerView()?.addSubview(toVC.view)
             
             toVC.view.backgroundColor = UIColor.clearColor()
             toVC.imageView.center.y += 20.0

--- a/PowerUpYourAnimations/Info.plist
+++ b/PowerUpYourAnimations/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.underplot.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/PowerUpYourAnimations/MAViewController.swift
+++ b/PowerUpYourAnimations/MAViewController.swift
@@ -30,7 +30,7 @@ class MAViewController: UIViewController {
         selection.lineDashPattern = [5, 3]
     }
  
-    override func touchesMoved(touches: Set<NSObject>, withEvent event: UIEvent) {
+    override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
         super.touchesMoved(touches, withEvent: event)
         
         // make the selection frame rect

--- a/PowerUpYourAnimations/MAViewController.swift
+++ b/PowerUpYourAnimations/MAViewController.swift
@@ -45,7 +45,7 @@ class MAViewController: UIViewController {
         selection.path = UIBezierPath(rect: selectionRect).CGPath
         
         //let the ants march!
-        UIView.animateWithDuration(0.5, delay: 0.0, options: .CurveLinear | .Repeat, animations: {
+        UIView.animateWithDuration(0.5, delay: 0.0, options: [.CurveLinear, .Repeat], animations: {
             self.selection.lineDashPhase = 8.0
             }, completion: nil)
         

--- a/PowerUpYourAnimations/MAViewController.swift
+++ b/PowerUpYourAnimations/MAViewController.swift
@@ -34,7 +34,8 @@ class MAViewController: UIViewController {
         super.touchesMoved(touches, withEvent: event)
         
         // make the selection frame rect
-        let location = (touches.first as! UITouch).locationInView(view)
+        guard let location = touches.first?.locationInView(view) else {return}
+        
         let selectionRect = CGRect(
             x: view.center.x - abs(location.x - view.center.x),
             y: view.center.y - abs(location.y - view.center.y),

--- a/PowerUpYourAnimations/TableCellAnimator.swift
+++ b/PowerUpYourAnimations/TableCellAnimator.swift
@@ -16,20 +16,26 @@ class TableCellAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     
     func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
         
-        let fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey) as! FlightsViewController
-        let toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as! FlightDetailsViewController
+        guard let
+            fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey) 
+                as? FlightsViewController,
+            toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) 
+                as? FlightDetailsViewController 
+        else {
+            return
+        }
         
-        transitionContext.containerView().insertSubview(toVC.view, belowSubview: fromVC.view)
+        transitionContext.containerView()?.insertSubview(toVC.view, belowSubview: fromVC.view)
         
         //make a snapshot of the selected cell
         let cellView = fromVC.selectedCellSnapshot()
-        transitionContext.containerView().addSubview(cellView)
+        transitionContext.containerView()?.addSubview(cellView)
 
         
         let width = fromVC.view.bounds.size.width
         toVC.view.transform = CGAffineTransformMakeTranslation(width, 0.0)
 
-        (UIApplication.sharedApplication().windows.first as! UIWindow).backgroundColor = UIColor.whiteColor()
+        UIApplication.sharedApplication().windows.first?.backgroundColor = UIColor.whiteColor()
         
         let duration = transitionDuration(transitionContext)
         

--- a/PowerUpYourAnimations/TableCellAnimator.swift
+++ b/PowerUpYourAnimations/TableCellAnimator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class TableCellAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     
-    func transitionDuration(transitionContext: UIViewControllerContextTransitioning) -> NSTimeInterval {
+    func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
         return 1.0
     }
     

--- a/PowerUpYourAnimations/TableCellAnimator.swift
+++ b/PowerUpYourAnimations/TableCellAnimator.swift
@@ -33,7 +33,7 @@ class TableCellAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         
         let duration = transitionDuration(transitionContext)
         
-        UIView.animateAndChainWithDuration(duration/4, delay: 0.0, options: nil, animations: {
+        UIView.animateAndChainWithDuration(NSTimeInterval(duration/4), delay: NSTimeInterval(0.0), options: [], animations: {
             //1st animation
             fromVC.view.transform = CGAffineTransformMakeTranslation(-width, 0.0)
             

--- a/PowerUpYourAnimations/TransitionImageView.swift
+++ b/PowerUpYourAnimations/TransitionImageView.swift
@@ -26,6 +26,14 @@ class TransitionImageView: UIImageView {
             fatalError("You need to have set an image, provide a new image and a mask to fire up a transition")
         }
         
+        guard let
+            filter = filter,
+            image = image,
+            maskImage = maskImage
+        else {
+            return
+        }
+        
         filter.setValue(CIImage(image: image),
             forKey: kCIInputImageKey)
         filter.setValue(CIImage(image: toImage),
@@ -40,19 +48,25 @@ class TransitionImageView: UIImageView {
         transitionStartTime = CACurrentMediaTime()
         
         displayLink = CADisplayLink(target: self, selector: Selector("timerFired:"))
-        displayLink!.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
+        displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
     }
     
     func timerFired(link: CADisplayLink) {
 
         let progress = (CACurrentMediaTime() - transitionStartTime) / duration
-        filter.setValue(progress, forKey: kCIInputTimeKey)
-        image = UIImage(CIImage: filter.outputImage,
-            scale: UIScreen.mainScreen().scale,
-            orientation: UIImageOrientation.Up)
+        
+        if let 
+            filter = filter, 
+            outputImage = filter.outputImage 
+        {
+            filter.setValue(progress, forKey: kCIInputTimeKey)
+            image = UIImage(CIImage: outputImage,
+                scale: UIScreen.mainScreen().scale,
+                orientation: UIImageOrientation.Up)
+        }
         
         if CACurrentMediaTime() > transitionStartTime + duration {
-            image = filter.valueForKey(kCIInputTargetImageKey) as? UIImage
+            image = filter?.valueForKey(kCIInputTargetImageKey) as? UIImage
             link.invalidate()
         }
     }

--- a/PowerUpYourAnimationsTests/Info.plist
+++ b/PowerUpYourAnimationsTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.underplot.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Hi Marin,

I really enjoyed watching the video of your AltWWDC talk, and wanted to show your stuff in action to some friends. But I'd already upgraded to Xcode 7, and the sample app wouldn't build. So I've gone through and gotten it working again.

I did notice 2 issues, but I'm not sure if they're related to my changes or not. Please let me know if I introduced these:
- The FlightController doesn't have a back button to return to the menu.
- In the simulator, the TimelineViewController never loads: the menu button remains highlighted and the app freezes. The "Super fatal error" UIAlert never appears. I haven't been able to test on-device yet.

Here's some more info on the changes I made:
- I upgraded to v1.0 of your awesome EasyAnimation library
- I let Xcode 7 turn on testability and set a value the new default product bundle identifier key.
- I updated the way the code sends animation option enum groupings / empty options (the new bracket syntax)
- I updated the method signatures for code that subclasses UIResponder touch events and conforms to the UIViewControllerAnimatedTransitioning protocol
- I unwrapped things that have become optional in Swift 2.

Cheers,
Jon
